### PR TITLE
Add support for parameters that have newlines in them.

### DIFF
--- a/HttpMultipartParser/MultipartFormDataParser.cs
+++ b/HttpMultipartParser/MultipartFormDataParser.cs
@@ -586,6 +586,7 @@ namespace HttpMultipartParser
             // an actual ParameterPart object with it. All we need to do is read data into a string
             // untill we hit the boundary
             var data = new StringBuilder();
+            bool firstTime = true;
             string line = reader.ReadLine();
             while (line != this.boundary && line != this.endBoundary)
             {
@@ -594,7 +595,16 @@ namespace HttpMultipartParser
                     throw new MultipartParseException("Unexpected end of section");
                 }
 
-                data.Append(line);
+                if (firstTime)
+                {
+                    data.Append(line);
+                    firstTime = false;
+                }
+                else
+                {
+                    data.Append(Environment.NewLine);
+                    data.Append(line);
+                }
                 line = reader.ReadLine();
             }
 

--- a/HttpMultipartParserUnitTest/HttpMultipartFormParserUnitTest.cs
+++ b/HttpMultipartParserUnitTest/HttpMultipartFormParserUnitTest.cs
@@ -311,6 +311,28 @@ namespace HttpMultipartParserUnitTest
         }
 
         /// <summary>
+        ///     Tests for correct handling of a multiline parameter.
+        /// </summary>
+        [TestMethod]
+        public void CorrectlyHandlesMultilineParameter()
+        {
+            string request = TestUtil.TrimAllLines(
+                @"-----------------------------41952539122868
+                Content-Disposition: form-data; name=""multilined""
+
+                line 1
+                line 2
+                line 3
+                -----------------------------41952539122868--");
+
+            using (Stream stream = TestUtil.StringToStream(request, Encoding.UTF8))
+            {
+                var parser = new MultipartFormDataParser(stream, Encoding.UTF8);
+                Assert.AreEqual(parser.Parameters["multilined"].Data, "line 1\r\nline 2\r\nline 3");
+            }
+        }
+
+        /// <summary>
         ///     Initializes the test data before each run, this primarily
         ///     consists of resetting data stream positions.
         /// </summary>


### PR DESCRIPTION
If a parameter has line breaks in it, the library just strips the white-space and joins the string together. 

This change adds support for parameters that have newlines in them.

Not sure if this is an in-spec change, but here it is in case you are interested in it.
