### PR TITLE
Allow not unique file names in one multipart request

### DIFF
--- a/Source/HttpMultipartParser/MultipartFormDataParser.cs
+++ b/Source/HttpMultipartParser/MultipartFormDataParser.cs
@@ -602,7 +602,7 @@ namespace HttpMultipartParser
             var streamingParser = new StreamingMultipartFormDataParser(stream, boundary, encoding, binaryBufferSize);
             streamingParser.ParameterHandler += parameterPart => Parameters.Add(parameterPart);
 
-            streamingParser.FileHandler += (name, fileName, type, disposition, buffer, bytes, partNo) =>
+            streamingParser.FileHandler += (name, fileName, type, disposition, buffer, bytes, partNumber) =>
             {
                 if (partNo == 0)
                 {

--- a/Source/HttpMultipartParser/MultipartFormDataParser.cs
+++ b/Source/HttpMultipartParser/MultipartFormDataParser.cs
@@ -559,7 +559,7 @@ namespace HttpMultipartParser
 
             streamingParser.FileHandler += (name, fileName, type, disposition, buffer, bytes, partNo) =>
             {
-                if (partNo == 0)
+                if (partNumber == 0)
                 {
                     // create file with first partNo
                     Files.Add(new FilePart(name, fileName, Utilities.MemoryStreamManager.GetStream(), type, disposition));

--- a/Source/HttpMultipartParser/MultipartFormDataParser.cs
+++ b/Source/HttpMultipartParser/MultipartFormDataParser.cs
@@ -604,7 +604,8 @@ namespace HttpMultipartParser
 
             streamingParser.FileHandler += (name, fileName, type, disposition, buffer, bytes, partNumber) =>
             {
-                if (partNo == 0)
+                if (partNumber == 0)
+
                 {
                     // create file with first partNo
                     Files.Add(new FilePart(name, fileName, Utilities.MemoryStreamManager.GetStream(), type, disposition));

--- a/Source/HttpMultipartParser/MultipartFormDataParser.cs
+++ b/Source/HttpMultipartParser/MultipartFormDataParser.cs
@@ -557,10 +557,11 @@ namespace HttpMultipartParser
             var streamingParser = new StreamingMultipartFormDataParser(stream, boundary, encoding, binaryBufferSize);
             streamingParser.ParameterHandler += parameterPart => Parameters.Add(parameterPart);
 
-            streamingParser.FileHandler += (name, fileName, type, disposition, buffer, bytes) =>
+            streamingParser.FileHandler += (name, fileName, type, disposition, buffer, bytes, partNo) =>
             {
-                if (Files.Count == 0 || name != Files[Files.Count - 1].Name)
+                if (partNo == 0)
                 {
+                    // create file with first partNo
                     Files.Add(new FilePart(name, fileName, Utilities.MemoryStreamManager.GetStream(), type, disposition));
                 }
 
@@ -601,10 +602,11 @@ namespace HttpMultipartParser
             var streamingParser = new StreamingMultipartFormDataParser(stream, boundary, encoding, binaryBufferSize);
             streamingParser.ParameterHandler += parameterPart => Parameters.Add(parameterPart);
 
-            streamingParser.FileHandler += (name, fileName, type, disposition, buffer, bytes) =>
+            streamingParser.FileHandler += (name, fileName, type, disposition, buffer, bytes, partNo) =>
             {
-                if (Files.Count == 0 || name != Files[Files.Count - 1].Name)
+                if (partNo == 0)
                 {
+                    // create file with first partNo
                     Files.Add(new FilePart(name, fileName, Utilities.MemoryStreamManager.GetStream(), type, disposition));
                 }
 

--- a/Source/HttpMultipartParser/MultipartFormDataParser.cs
+++ b/Source/HttpMultipartParser/MultipartFormDataParser.cs
@@ -557,7 +557,7 @@ namespace HttpMultipartParser
             var streamingParser = new StreamingMultipartFormDataParser(stream, boundary, encoding, binaryBufferSize);
             streamingParser.ParameterHandler += parameterPart => Parameters.Add(parameterPart);
 
-            streamingParser.FileHandler += (name, fileName, type, disposition, buffer, bytes, partNo) =>
+            streamingParser.FileHandler += (name, fileName, type, disposition, buffer, bytes, partNumber) =>
             {
                 if (partNumber == 0)
                 {

--- a/Source/HttpMultipartParser/MultipartFormDataParser.cs
+++ b/Source/HttpMultipartParser/MultipartFormDataParser.cs
@@ -605,7 +605,6 @@ namespace HttpMultipartParser
             streamingParser.FileHandler += (name, fileName, type, disposition, buffer, bytes, partNumber) =>
             {
                 if (partNumber == 0)
-
                 {
                     // create file with first partNo
                     Files.Add(new FilePart(name, fileName, Utilities.MemoryStreamManager.GetStream(), type, disposition));

--- a/Source/HttpMultipartParser/StreamingMultipartFormDataParser.cs
+++ b/Source/HttpMultipartParser/StreamingMultipartFormDataParser.cs
@@ -293,7 +293,7 @@ namespace HttpMultipartParser
         /// <param name="bytes">The length of data in buffer.</param>
         /// <param name="partNo">Serial number of long file part (begins from 0).</param>
         public delegate void FileStreamDelegate(
-            string name, string fileName, string contentType, string contentDisposition, byte[] buffer, int bytes, int partNo);
+            string name, string fileName, string contentType, string contentDisposition, byte[] buffer, int bytes, int partNumber);
 
         /// <summary>
         /// The StreamClosedDelegate defining functions that can handle stream being closed.

--- a/Source/HttpMultipartParser/StreamingMultipartFormDataParser.cs
+++ b/Source/HttpMultipartParser/StreamingMultipartFormDataParser.cs
@@ -291,8 +291,9 @@ namespace HttpMultipartParser
         /// <param name="contentDisposition">The content disposition of the multipart data.</param>
         /// <param name="buffer">Some of the data from the file (not neccecarily all of the data).</param>
         /// <param name="bytes">The length of data in buffer.</param>
+        /// <param name="partNo">Serial number of long file part (begins from 0).</param>
         public delegate void FileStreamDelegate(
-            string name, string fileName, string contentType, string contentDisposition, byte[] buffer, int bytes);
+            string name, string fileName, string contentType, string contentDisposition, byte[] buffer, int bytes, int partNo);
 
         /// <summary>
         /// The StreamClosedDelegate defining functions that can handle stream being closed.
@@ -551,6 +552,8 @@ namespace HttpMultipartParser
         /// </param>
         private void ParseFilePart(Dictionary<string, string> parameters, RebufferableBinaryReader reader)
         {
+            int partNumber = 0; // begins count parts of file from 0
+
             string name = parameters["name"];
             string filename = parameters["filename"];
 
@@ -652,7 +655,7 @@ namespace HttpMultipartParser
                     // We also want to chop off the newline that is inserted by the protocl.
                     // We can do this by reducing endPos by the length of newline in this environment
                     // and encoding
-                    FileHandler(name, filename, contentType, contentDisposition, fullBuffer, endPos - bufferNewlineLength);
+                    FileHandler(name, filename, contentType, contentDisposition, fullBuffer, endPos - bufferNewlineLength, partNumber);
 
                     int writeBackOffset = endPos + endPosLength + boundaryNewlineOffset;
                     int writeBackAmount = (prevLength + curLength) - writeBackOffset;
@@ -662,7 +665,8 @@ namespace HttpMultipartParser
                 }
 
                 // No end, consume the entire previous buffer
-                FileHandler(name, filename, contentType, contentDisposition, prevBuffer, prevLength);
+                FileHandler(name, filename, contentType, contentDisposition, prevBuffer, prevLength, partNumber);
+                partNumber++; // increase part counter
 
                 // Now we want to swap the two buffers, we don't care
                 // what happens to the data from prevBuffer so we set
@@ -700,6 +704,8 @@ namespace HttpMultipartParser
         /// </returns>
         private async Task ParseFilePartAsync(Dictionary<string, string> parameters, RebufferableBinaryReader reader, CancellationToken cancellationToken = default)
         {
+            int partNumber = 0; // begins count parts of file from 0
+
             string name = parameters["name"];
             string filename = parameters["filename"];
 
@@ -801,7 +807,7 @@ namespace HttpMultipartParser
                     // We also want to chop off the newline that is inserted by the protocl.
                     // We can do this by reducing endPos by the length of newline in this environment
                     // and encoding
-                    FileHandler(name, filename, contentType, contentDisposition, fullBuffer, endPos - bufferNewlineLength);
+                    FileHandler(name, filename, contentType, contentDisposition, fullBuffer, endPos - bufferNewlineLength, partNumber);
 
                     int writeBackOffset = endPos + endPosLength + boundaryNewlineOffset;
                     int writeBackAmount = (prevLength + curLength) - writeBackOffset;
@@ -811,7 +817,8 @@ namespace HttpMultipartParser
                 }
 
                 // No end, consume the entire previous buffer
-                FileHandler(name, filename, contentType, contentDisposition, prevBuffer, prevLength);
+                FileHandler(name, filename, contentType, contentDisposition, prevBuffer, prevLength, partNumber);
+                partNumber++; // increase part counter
 
                 // Now we want to swap the two buffers, we don't care
                 // what happens to the data from prevBuffer so we set

--- a/Source/HttpMultipartParser/StreamingMultipartFormDataParser.cs
+++ b/Source/HttpMultipartParser/StreamingMultipartFormDataParser.cs
@@ -292,7 +292,6 @@ namespace HttpMultipartParser
         /// <param name="buffer">Some of the data from the file (not neccecarily all of the data).</param>
         /// <param name="bytes">The length of data in buffer.</param>
         /// <param name="partNumber">Each chunk (or "part") in a given file is sequentially numbered, starting at zero.</param>
-
         public delegate void FileStreamDelegate(
             string name, string fileName, string contentType, string contentDisposition, byte[] buffer, int bytes, int partNumber);
 

--- a/Source/HttpMultipartParser/StreamingMultipartFormDataParser.cs
+++ b/Source/HttpMultipartParser/StreamingMultipartFormDataParser.cs
@@ -291,7 +291,8 @@ namespace HttpMultipartParser
         /// <param name="contentDisposition">The content disposition of the multipart data.</param>
         /// <param name="buffer">Some of the data from the file (not neccecarily all of the data).</param>
         /// <param name="bytes">The length of data in buffer.</param>
-        /// <param name="partNo">Serial number of long file part (begins from 0).</param>
+        /// <param name="partNumber">Each chunk (or "part") in a given file is sequentially numbered, starting at zero.</param>
+
         public delegate void FileStreamDelegate(
             string name, string fileName, string contentType, string contentDisposition, byte[] buffer, int bytes, int partNumber);
 


### PR DESCRIPTION
If files have the same names in one request, the original code lost some data. Previously files created when filename change. Now a file parts counter is added and a new file is created with the first part of a new file