### PR TITLE
Add comparison option to GetParametersValue(s)

### DIFF
--- a/Source/HttpMultipartParser.UnitTests/ParserScenarios/TinyData.cs
+++ b/Source/HttpMultipartParser.UnitTests/ParserScenarios/TinyData.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -228,6 +229,50 @@ namespace HttpMultipartParser.UnitTests.ParserScenarios
 			{
 				var parser = await MultipartFormDataParser.ParseAsync(stream, "boundry", Encoding.UTF8).ConfigureAwait(false);
 				Assert.Null(parser.GetParameterValue("does not exist"));
+			}
+		}
+
+		[Fact]
+		public void GetParameterValueReturnsCorrectlyWithoutComparisonType()
+		{
+			using (Stream stream = TestUtil.StringToStream(_testCase.Request, Encoding.UTF8))
+			{
+				var parser = MultipartFormDataParser.Parse(stream, "boundry", Encoding.UTF8);
+				Assert.NotNull(parser.GetParameterValue("text"));
+				Assert.Null(parser.GetParameterValue("Text"));
+			}
+		}
+
+		[Fact]
+		public async Task GetParameterValueReturnsCorrectlyWithoutComparisonTypeAsync()
+		{
+			using (Stream stream = TestUtil.StringToStream(_testCase.Request, Encoding.UTF8))
+			{
+				var parser = await MultipartFormDataParser.ParseAsync(stream, "boundry", Encoding.UTF8);
+				Assert.NotNull(parser.GetParameterValue("text"));
+				Assert.Null(parser.GetParameterValue("Text"));
+			}
+		}
+
+		[Fact]
+		public void GetParameterValueReturnsCorrectlyWithComparisonType()
+		{
+			using (Stream stream = TestUtil.StringToStream(_testCase.Request, Encoding.UTF8))
+			{
+				var parser = MultipartFormDataParser.Parse(stream, "boundry", Encoding.UTF8);
+				Assert.NotNull(parser.GetParameterValue("text",StringComparison.OrdinalIgnoreCase));
+				Assert.NotNull(parser.GetParameterValue("Text",StringComparison.OrdinalIgnoreCase));
+			}
+		}
+
+		[Fact]
+		public async Task GetParameterValueReturnsCorrectlyWithComparisonTypeAsync()
+		{
+			using (Stream stream = TestUtil.StringToStream(_testCase.Request, Encoding.UTF8))
+			{
+				var parser = await MultipartFormDataParser.ParseAsync(stream, "boundry", Encoding.UTF8);
+				Assert.NotNull(parser.GetParameterValue("text",StringComparison.OrdinalIgnoreCase));
+				Assert.NotNull(parser.GetParameterValue("Text",StringComparison.OrdinalIgnoreCase));
 			}
 		}
 

--- a/Source/HttpMultipartParser/Extensions.cs
+++ b/Source/HttpMultipartParser/Extensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -28,10 +29,11 @@ namespace HttpMultipartParser
 		/// </summary>
 		/// <param name="parser">The multipart form parser.</param>
 		/// <param name="name">The name of the parameter.</param>
+		/// <param name="comparisonType">One of the enumeration values that specifies how the strings will be compared.</param>
 		/// <returns>The value of the parameter.</returns>
-		public static string GetParameterValue(this IMultipartFormDataParser parser, string name)
+		public static string GetParameterValue(this IMultipartFormDataParser parser, string name, StringComparison comparisonType = StringComparison.Ordinal)
 		{
-			return parser.GetParameterValues(name).FirstOrDefault();
+			return parser.GetParameterValues(name, comparisonType).FirstOrDefault();
 		}
 
 		/// <summary>
@@ -39,11 +41,12 @@ namespace HttpMultipartParser
 		/// </summary>
 		/// <param name="parser">The multipart form parser.</param>
 		/// <param name="name">The name of the parameter.</param>
+		/// <param name="comparisonType">One of the enumeration values that specifies how the strings will be compared.</param>
 		/// <returns>The values of the parameter.</returns>
-		public static IEnumerable<string> GetParameterValues(this IMultipartFormDataParser parser, string name)
+		public static IEnumerable<string> GetParameterValues(this IMultipartFormDataParser parser, string name, StringComparison comparisonType = StringComparison.Ordinal)
 		{
 			return parser.Parameters
-				.Where(p => p.Name == name)
+				.Where(p => p.Name.Equals(name, comparisonType))
 				.Select(p => p.Data);
 		}
 	}


### PR DESCRIPTION
I found having a case insensitive option to be useful where API contracts were poorly defined.